### PR TITLE
Releases: Bumped chart versions to address release failure

### DIFF
--- a/charts/aerospike/Chart.yaml
+++ b/charts/aerospike/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: aerospike
 sources:
   - https://aerospike.com/
-version: 0.0.7
+version: 0.0.8

--- a/charts/apache-activemq/Chart.yaml
+++ b/charts/apache-activemq/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: apache-activemq
 sources:
   - https://activemq.apache.org/components/classic/documentation
-version: 0.0.7
+version: 0.0.8

--- a/charts/apache-hadoop/Chart.yaml
+++ b/charts/apache-hadoop/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: hadoop
 sources:
   - https://hadoop.apache.org/
-version: 0.0.2
+version: 0.0.3

--- a/charts/apache-mesos/Chart.yaml
+++ b/charts/apache-mesos/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: mesos
 sources:
   - https://mesos.apache.org/
-version: 0.0.6
+version: 0.0.7

--- a/charts/cassandra/Chart.yaml
+++ b/charts/cassandra/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: apache-cassandra
 sources:
   - https://github.com/apache/cassandra
-version: 0.1.5
+version: 0.1.6

--- a/charts/couchbase-community/Chart.yaml
+++ b/charts/couchbase-community/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: couchbase
 sources:
   - https://www.couchbase.com/
-version: 0.0.3
+version: 0.0.4

--- a/charts/mssql/Chart.yaml
+++ b/charts/mssql/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: mssql
 sources:
   - https://github.com/Microsoft/mssql-docker
-version: 0.0.2
+version: 0.0.3

--- a/charts/oracledbxe/Chart.yaml
+++ b/charts/oracledbxe/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: oracledbxe
 sources:
   - https://github.com/gvenzl/oci-oracle-xe
-version: 0.0.1
+version: 0.0.2

--- a/charts/squid/Chart.yaml
+++ b/charts/squid/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: squid
 sources:
   - https://github.com/squid-cache/squid
-version: 0.0.3
+version: 0.0.4

--- a/charts/tensorflow/Chart.yaml
+++ b/charts/tensorflow/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: tensorflow
 sources:
   - https://github.com/tensorflow/serving
-version: 0.0.8
+version: 0.0.9

--- a/charts/varnish/Chart.yaml
+++ b/charts/varnish/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: varnish
 sources:
   - https://varnish-cache.org/
-version: 0.0.7
+version: 0.0.8

--- a/charts/wildfly/Chart.yaml
+++ b/charts/wildfly/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 name: wildfly
 sources:
   - https://github.com/wildfly/wildfly
-version: 0.0.3
+version: 0.0.4


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Changes
* [bumped all chart versions where appropriate to fix failing release](https://github.com/observIQ/application-helm-charts/commit/ac68ba13844c4ea134d140fa9f35f867a02c288b)

## Description of Changes

The release are failing, I believe this was due to a mistake in not bumping chart versions in #87 so we're bumping them with this PR to hopefully address the failure.

Error Message from failure:
```
Releasing charts...
Error: error creating GitHub release aerospike-0.0.7: POST https://api.github.com/repos/observIQ/application-helm-charts/releases: 422 Validation Failed [{Resource:Release Field:tag_name Code:already_exists Message:}]
```

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
