### PR TITLE
Bump chart versions for Discourse and Clickhouse

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -11,6 +11,6 @@ keywords:
 name: clickhouse
 sources:
 - https://github.com/observIQ/charts
-version: 3.2.4
+version: 3.2.5
 maintainers:
   - name: observIQ

--- a/charts/discourse/Chart.yaml
+++ b/charts/discourse/Chart.yaml
@@ -29,4 +29,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/discourse
   - https://github.com/spinnaker
   - https://www.discourse.org/
-version: 9.0.11
+version: 9.0.12


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Changes
* [Bumped chart versions for Discourse and Clickhouse](https://github.com/observIQ/application-helm-charts/commit/ba850196f3683af827cecd34391370e04a3fa38f)

## Description of Changes

I believed that these two didn't need to be bumped due to the fact that no changes to these were included in #87 but the release is still failing, and now it happens to be failing on those charts.

Error:
```
Error: error creating GitHub release discourse-9.0.11: POST https://api.github.com/repos/observIQ/application-helm-charts/releases: 422 Validation Failed [{Resource:Release Field:tag_name Code:already_exists Message:}]
```

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
