### PR TITLE
Presto: Update JMX exporter configuration

### DIFF
--- a/charts/presto/Chart.yaml
+++ b/charts/presto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: presto
 description: Customized version of the official Helm chart for Presto
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: "0.283"
 home: https://prestodb.io
 icon: https://prestodb.io/docs/current/_static/logo.png

--- a/charts/presto/templates/configmap-jmx.yaml
+++ b/charts/presto/templates/configmap-jmx.yaml
@@ -8,4 +8,53 @@ data:
     lowercaseOutputLabelNames: true
     lowercaseOutputName: true
     rules:
-    - pattern: ".*"
+      - pattern: "com.facebook.presto.execution<name=TaskManager><>(.+): (.*)"
+        name: "presto_TaskManager_$1"
+        value: $2
+        type: GAUGE
+        attrNameSnakeCase: false
+      - pattern: "com.facebook.presto.execution.executor<name=TaskExecutor><>(.+): (.*)"
+        name: "presto_TaskExecutor_$1"
+        value: $2
+        type: GAUGE
+      - pattern: "com.facebook.presto.failureDetector<name=HeartbeatFailureDetector><>ActiveCount: (.*)"
+        name: "presto_HeartbeatDetector_ActiveCount"
+        value: $1
+        type: GAUGE
+        attrNameSnakeCase: false
+      - pattern: "com.facebook.presto.metadata<name=DiscoveryNodeManager><>(.+): (.*)"
+        name: "presto_metadata_DiscoveryNodeManager_$1"
+        value: $2
+        type: GAUGE
+        attrNameSnakeCase: false
+      - pattern: "com.facebook.presto.execution<name=QueryManager><>(.+): (.*)"
+        name: "presto_QueryManager_$1"
+        value: $2
+        type: GAUGE
+      - pattern: "com.facebook.presto.execution<name=QueryExecution><>(.+): (.*)"
+        name: "presto_QueryExecution_$1"
+        value: $2
+        attrNameSnakeCase: false
+      - pattern: "com.facebook.presto.memory<name=ClusterMemoryManager><>(.+): (.*)"
+        name: "presto_ClusterMemoryManager_$1"
+        value: $2
+        type: GAUGE
+        attrNameSnakeCase: false
+      - pattern: "com.facebook.presto.memory<type=ClusterMemoryPool, name=(.*)><>(.+): (.*)"
+        name: "presto_ClusterMemoryPool_$1_$2"
+        type: GAUGE
+      - pattern: "com.facebook.presto.memory<type=MemoryPool, name=(.*)><>(.+): (.*)"
+        name: "presto_MemoryPool_$1_$2"
+        type: GAUGE
+      - pattern: 'java.lang<name=([^>]+), type=GarbageCollector><LastGcInfo>duration: (\d+)'
+        name: jvm_gc_duration
+        value: $2
+        labels:
+          name: $1
+        type: GAUGE
+      - pattern: 'java.lang<name=([^>]+), type=GarbageCollector><>CollectionCount: (\d+)'
+        name: jvm_gc_collection_count
+        value: $2
+        labels:
+          name: $1
+        type: GAUGE

--- a/charts/presto/templates/configmap-jmx.yaml
+++ b/charts/presto/templates/configmap-jmx.yaml
@@ -11,26 +11,26 @@ data:
       - pattern: "com.facebook.presto.execution<name=TaskManager><>(.+): (.*)"
         name: "presto_TaskManager_$1"
         value: $2
-        type: GAUGE
+        type: UNTYPED
         attrNameSnakeCase: false
       - pattern: "com.facebook.presto.execution.executor<name=TaskExecutor><>(.+): (.*)"
         name: "presto_TaskExecutor_$1"
         value: $2
-        type: GAUGE
+        type: UNTYPED
       - pattern: "com.facebook.presto.failureDetector<name=HeartbeatFailureDetector><>ActiveCount: (.*)"
         name: "presto_HeartbeatDetector_ActiveCount"
         value: $1
-        type: GAUGE
+        type: UNTYPED
         attrNameSnakeCase: false
       - pattern: "com.facebook.presto.metadata<name=DiscoveryNodeManager><>(.+): (.*)"
         name: "presto_metadata_DiscoveryNodeManager_$1"
         value: $2
-        type: GAUGE
+        type: UNTYPED
         attrNameSnakeCase: false
       - pattern: "com.facebook.presto.execution<name=QueryManager><>(.+): (.*)"
         name: "presto_QueryManager_$1"
         value: $2
-        type: GAUGE
+        type: UNTYPED
       - pattern: "com.facebook.presto.execution<name=QueryExecution><>(.+): (.*)"
         name: "presto_QueryExecution_$1"
         value: $2
@@ -38,23 +38,35 @@ data:
       - pattern: "com.facebook.presto.memory<name=ClusterMemoryManager><>(.+): (.*)"
         name: "presto_ClusterMemoryManager_$1"
         value: $2
-        type: GAUGE
+        type: UNTYPED
         attrNameSnakeCase: false
       - pattern: "com.facebook.presto.memory<type=ClusterMemoryPool, name=(.*)><>(.+): (.*)"
         name: "presto_ClusterMemoryPool_$1_$2"
-        type: GAUGE
+        type: UNTYPED
       - pattern: "com.facebook.presto.memory<type=MemoryPool, name=(.*)><>(.+): (.*)"
         name: "presto_MemoryPool_$1_$2"
-        type: GAUGE
+        type: UNTYPED
       - pattern: 'java.lang<name=([^>]+), type=GarbageCollector><LastGcInfo>duration: (\d+)'
         name: jvm_gc_duration
         value: $2
         labels:
           name: $1
-        type: GAUGE
+        type: UNTYPED
       - pattern: 'java.lang<name=([^>]+), type=GarbageCollector><>CollectionCount: (\d+)'
         name: jvm_gc_collection_count
         value: $2
         labels:
           name: $1
-        type: GAUGE
+        type: UNTYPED
+      - pattern: "java.lang<type=Memory><HeapMemoryUsage>used"
+        name: jvm_heap_memory_used
+        type: UNTYPED
+      - pattern: "java.lang<type=Memory><HeapMemoryUsage>committed"
+        name: jvm_heap_memory_committed
+        type: UNTYPED
+      - pattern: "java.lang<type=Memory><NonHeapMemoryUsage>used"
+        name: jvm_nonheap_memory_used
+        type: UNTYPED
+      - pattern: "java.lang<type=Memory><NonHeapMemoryUsage>committed"
+        name: jvm_nonheap_memory_committed
+        type: UNTYPED


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Changes
* [Updated the jmx exporter configuration for Presto metrics](https://github.com/observIQ/application-helm-charts/commit/a6b7bd080636b94d6613bcaa52bdb5d23ff785ba)
* [bumped chart version to 1.0.4](https://github.com/observIQ/application-helm-charts/commit/f0c8ea48785cf9466bab8ba1b903d5ec12de521b)
* [updated the jmx exporter configuration to include jvm metrics](https://github.com/observIQ/application-helm-charts/pull/103/commits/c4e0ec3f65a86adf54d8260cc922b61499c1fbfc)

## Description of Changes

This is a change to update the JMX exporter configuration for Presto so that the metrics are formatted how we'd like them to be.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
