### PR TITLE
InfluxDB: Add loadgen to chart

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 2.3.0
 name: influxdb2
 description: A customized InfluxDB v2 chart for development
 type: application
-version: 1.0.0
+version: 1.0.1

--- a/charts/influxdb/templates/cronjob-loadgen.yaml
+++ b/charts/influxdb/templates/cronjob-loadgen.yaml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: influxdb-loadgen
+  namespace: default
+spec:
+  schedule: "*/10 * * * *"
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      parallelism: 1
+      template:
+        spec:
+          containers:
+          - name: influxdb-loadgen
+            image: {{ .Values.loadgenImage }}
+            imagePullPolicy: IfNotPresent
+          restartPolicy: Never

--- a/charts/influxdb/templates/cronjob-loadgen.yaml
+++ b/charts/influxdb/templates/cronjob-loadgen.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: influxdb-loadgen
-  namespace: default
+  namespace: {{ .Values.loadgenNamespace }}
 spec:
   schedule: "*/10 * * * *"
   successfulJobsHistoryLimit: 1

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -1,4 +1,5 @@
 loadgenImage: ghcr.io/observiq/influxdb-loadgen:5ef8a34
+loadgenNamespace: sample-apps
 image:
   repository: influxdb
   tag: 2.3.0-alpine

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -1,3 +1,4 @@
+loadgenImage: ghcr.io/observiq/influxdb-loadgen:5ef8a34
 image:
   repository: influxdb
   tag: 2.3.0-alpine


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Changes
* [updated loadgen cronjob to use image released by ci](https://github.com/observIQ/application-helm-charts/commit/6943ff61f74f1727afc5fc54f050189be8a89dfd)
* [bumped chart version to 1.0.1](https://github.com/observIQ/application-helm-charts/commit/2fdbe9664b2217df14b344a0febd2f443acfbba4)

## Description of Changes

Bumped the chart to a new version. Updated the load generation cronjob resource to pull the image from the `values.yaml` file. Specified the image that was built by CI to be used.

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
